### PR TITLE
feat: add mcp catalog support

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,6 +6,13 @@
         "@playwright/mcp@latest"
       ],
       "env": {}
+    },
+    "catalog": {
+      "command": "npx",
+      "args": [
+        "mcp-catalog"
+      ],
+      "env": {}
     }
   }
 }

--- a/Examples/agents/mcp-catalog-snippet.md
+++ b/Examples/agents/mcp-catalog-snippet.md
@@ -1,0 +1,11 @@
+# MCP Catalog Usage Snippet
+
+<example>
+Context: The developer wants to know which MCP tools are available for code analysis.
+user: "What MCP tools can help analyze this repository?"
+assistant: "I'll check mcp-catalog for relevant tools."
+<commentary>
+Use the Task tool to invoke `mcp-catalog` and list candidate tools.
+</commentary>
+assistant: "mcp-catalog suggests: filesystem, github, playwright"
+</example>

--- a/Examples/agents/specialists/TEMPLATE-agent.md
+++ b/Examples/agents/specialists/TEMPLATE-agent.md
@@ -35,14 +35,15 @@ Save the implementation plan to .claude/doc/[agent-type]-[task]-[timestamp].md i
 
 ## Core Workflow
 1. Check .claude/tasks/ for the most recent context_session_*.md file for full context
-2. Use Context7 MCP to get latest documentation for:
+2. Use mcp-catalog to list candidate MCP tools for this task
+3. Use Context7 MCP to get latest documentation for:
    - [Relevant framework/library 1]
    - [Relevant framework/library 2]
    - [Best practices documentation]
-3. Use WebSearch for latest updates and changelogs not in Context7
-4. [Additional MCP tools as needed - Sequential, Magic, Playwright, AWS]
-5. Create detailed implementation plan with [specific deliverables]
-6. Save plan to .claude/doc/ in the project directory
+4. Use WebSearch for latest updates and changelogs not in Context7
+5. [Additional MCP tools as needed - Sequential, Magic, Playwright, AWS]
+6. Create detailed implementation plan with [specific deliverables]
+7. Save plan to .claude/doc/ in the project directory
 
 ## Output Format
 Your final message MUST include the implementation file path you created. No need to recreate the same content again in the final message.
@@ -56,6 +57,7 @@ Example: "I've created a detailed [type] plan at .claude/doc/[agent-type]-[descr
 - After finishing work, MUST create the .claude/doc/*.md file in the project directory
 - Use Context7 MCP for latest documentation
 - Use WebSearch for recent updates
+- Use mcp-catalog to discover relevant MCP tools
 - [Additional MCP-specific rules]
 - Always include [domain-specific requirements]
 - Document [specific technical aspects]

--- a/cli/commands/mcp.js
+++ b/cli/commands/mcp.js
@@ -31,6 +31,14 @@ const MCP_SERVERS = {
         GITHUB_TOKEN: process.env.GITHUB_TOKEN || ""
       }
     }
+  },
+  catalog: {
+    package: 'mcp-catalog',
+    config: {
+      command: "npx",
+      args: ["mcp-catalog"],
+      env: {}
+    }
   }
 };
 
@@ -45,7 +53,8 @@ async function setupMCP(serverName) {
         choices: [
           { name: 'Playwright - Browser automation & visual development', value: 'playwright', checked: true },
           { name: 'Filesystem - Enhanced file operations', value: 'filesystem' },
-          { name: 'GitHub - GitHub API integration', value: 'github' }
+          { name: 'GitHub - GitHub API integration', value: 'github' },
+          { name: 'Catalog - Discover available MCP tools', value: 'catalog' }
         ]
       }
     ]);

--- a/cli/commands/setup.js
+++ b/cli/commands/setup.js
@@ -143,7 +143,7 @@ async function execute() {
   let mcpServers = [];
   if (hasMcp.toLowerCase() === 'y') {
     console.log('Select MCP servers to use:');
-    const servers = ['Context7', 'Sequential', 'Magic', 'Playwright', 'AWS', 'WebSearch'];
+    const servers = ['Context7', 'Sequential', 'Magic', 'Playwright', 'AWS', 'WebSearch', 'Catalog'];
     
     for (const server of servers) {
       const use = await question(chalk.cyan(`Use ${server}? (y/n): `));


### PR DESCRIPTION
## Summary
- configure `mcp-catalog` server in setup scripts and default MCP config
- document catalog usage in agent template
- add snippet illustrating mcp-catalog listing tools

## Testing
- `npm test` *(fails: Playwright browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2a7d940c8331a052b07a21503eb7