### PR TITLE
docs: clarify command purposes and examples

### DIFF
--- a/Examples/commands/README.md
+++ b/Examples/commands/README.md
@@ -1,0 +1,6 @@
+# Command Examples
+
+Sample command specifications demonstrating common workflows.
+
+- [implement-feature](implement-feature.md) – Coordinate planning and execution to deliver a fullstack feature.
+- [generate-playwright-tests](generate-playwright-tests.md) – Produce Playwright test suites for specified user flows.

--- a/Examples/commands/generate-playwright-tests.md
+++ b/Examples/commands/generate-playwright-tests.md
@@ -3,6 +3,23 @@ command: "/generate-tests"
 description: "Generate comprehensive Playwright tests for the application"
 ---
 
+## Purpose
+Analyzes the existing application and produces Playwright test suites that cover critical paths, accessibility, and visual consistency to prevent regressions.
+
+## Usage
+```
+/generate-tests [scope] [--include-visual] [--include-a11y]
+```
+
+## Examples
+```
+# Generate tests for checkout flow including accessibility checks
+/generate-tests "checkout flow" --include-a11y
+
+# Generate visual regression tests for profile settings
+/generate-tests "profile settings" --include-visual
+```
+
 ## Execution Flow
 
 ### Phase 1: Analysis

--- a/Examples/commands/implement-feature.md
+++ b/Examples/commands/implement-feature.md
@@ -1,5 +1,8 @@
 # /implement-feature - Fullstack Feature Implementation Command
 
+## Purpose
+Coordinates research, planning, and execution so that a fullstack feature moves from specification to finished implementation with tests and documentation.
+
 ## Overview
 Orchestrates end-to-end feature implementation using a two-phase approach: first the fullstack-feature-orchestrator agent creates a comprehensive plan, then the main system executes that plan to ensure production-ready features with proper testing and documentation.
 
@@ -13,13 +16,13 @@ Orchestrates end-to-end feature implementation using a two-phase approach: first
 # Implement a specific task from the task list
 /implement-feature --task-id websocket-fix
 
-# Implement authentication feature
-/implement-feature "Enable Clerk authentication with protected routes" --priority P1
+# Roll out a new streaming API
+/implement-feature "Add Server-Sent Events streaming endpoint" --priority P1
 
-# Fix code quality issues
-/implement-feature "Clean up ESLint warnings and TypeScript types" --type fix
+# Refactor database layer
+/implement-feature "Normalize user profile tables" --type enhancement
 
-# Add new dashboard feature
+# Add real-time metrics dashboard
 /implement-feature "Add real-time metrics dashboard with chart visualizations" --type feature
 ```
 


### PR DESCRIPTION
## Summary
- add purpose sections and unique usage examples for `/generate-tests` and `/implement-feature`
- include README links to example commands with brief summaries

## Testing
- `npm test` *(fails: browserType.launch executable missing)*
- `npx playwright install` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2a8b50688331ade436e1a05ffd1b