### PR TITLE
Clarify Playwright specialist roles and command

### DIFF
--- a/Examples/agents/specialists/playwright-test-engineer.md
+++ b/Examples/agents/specialists/playwright-test-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: playwright-test-engineer
-description: Use this agent when you need to create, plan, or design Playwright tests for E2E testing, visual regression testing, interaction testing, or accessibility testing. This agent specializes in test scenario design, page object creation, test data management, and CI/CD test optimization. The agent creates comprehensive test plans but never executes tests directly.
+description: Use this agent when you need to create, plan, or design Playwright tests for CI pipelines, including E2E testing, visual regression testing, interaction testing, or accessibility testing. This agent specializes in test scenario design, page object creation, test data management, and CI/CD test optimization. For iterative UI design and visual refinement, choose the `playwright-visual-developer` agent instead. The agent creates comprehensive test plans but never executes tests directly.
 
 Examples:
 - <example>
@@ -31,6 +31,10 @@ Examples:
 model: sonnet
 color: green
 ---
+
+# Playwright Test Engineer (CI Specialist)
+
+> Use this agent for CI-focused Playwright test planning. For visual design iteration, use the `playwright-visual-developer` agent.
 
 You are an expert Playwright Test Engineer specializing in E2E testing, visual regression testing, interaction testing, and test automation for web applications. Your expertise spans test architecture, CI/CD integration, and creating maintainable test suites.
 

--- a/Examples/agents/specialists/playwright-visual-developer.md
+++ b/Examples/agents/specialists/playwright-visual-developer.md
@@ -1,10 +1,14 @@
 ---
 name: playwright-visual-developer
-description: Implements pixel-perfect UI using Playwright MCP for visual iteration
+description: Implements pixel-perfect UI using Playwright MCP for design iteration. For CI-focused test planning and automation, choose the `playwright-test-engineer` agent instead.
 model: sonnet
 tools: Write, Read, MultiEdit, playwright_navigate, playwright_screenshot, playwright_set_viewport, playwright_evaluate
 parallel: true
 ---
+
+# Playwright Visual Developer (Design Iteration Specialist)
+
+> Use this agent for visual design iteration and pixel-perfect refinement. For CI test planning and automation, use the `playwright-test-engineer` agent.
 
 You are a visual development specialist using Playwright MCP for iterative UI refinement.
 

--- a/Examples/commands/generate-playwright-tests.md
+++ b/Examples/commands/generate-playwright-tests.md
@@ -1,19 +1,19 @@
----
-command: "/generate-tests"
-description: "Generate comprehensive Playwright tests for the application"
+command: "/generate-playwright-tests"
+description: "Invoke from the main context to generate Playwright tests, delegating planning to the `playwright-test-engineer` and maintaining session context"
 ---
 
 ## Execution Flow
 
 ### Phase 1: Analysis
-1. Read .claude/tasks/ for the most recent context_session_*.md file for current context
+1. Look for .claude/tasks/context_session_[session_id].md; if missing, write current context to that path and use it going forward
 2. Analyze application structure and routes
 3. Identify critical user paths
 4. Check .ai/memory/patterns/ for existing test patterns
 5. Review .ai/memory/test-results/ for historical test data
+6. Append any analysis results to the session context file to keep it current
 
-### Phase 2: Test Planning
-Invoke playwright-test-engineer agent to create test plan:
+### Phase 2: Test Planning (Delegates to Test Engineer)
+Explicitly invoke the `playwright-test-engineer` agent to create the test plan:
 ```
 invoke_agent(
   agent: "playwright-test-engineer",
@@ -22,6 +22,7 @@ invoke_agent(
   expect_output: ".claude/doc/playwright-tests-*.md"
 )
 ```
+After the specialist completes, append a summary of its output to `contextFilePath` so the session context stays current before invoking any additional subagents.
 
 ### Phase 3: Test Generation
 Based on the plan, generate:


### PR DESCRIPTION
## Summary
- Highlight CI-focused responsibilities in `playwright-test-engineer` and cross-reference `playwright-visual-developer`
- Emphasize design-iteration duties in `playwright-visual-developer` and link back to the Test Engineer
- Make `/generate-playwright-tests` command explicitly manage session context and delegate planning to the Test Engineer

## Testing
- `timeout 30s npm test` *(fails: Playwright browser executables missing)*
- `npx playwright install` *(fails: 403 Domain forbidden while downloading browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2a8c2ed48331bdfe2732c329fa6e