### PR TITLE
test: add Playwright CLI coverage and mobile placeholders

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -55,6 +55,13 @@ module.exports = defineConfig({
         ...devices['Desktop Chrome'],
       },
     },
+    {
+      name: 'visual-tests',
+      testMatch: /.*\.visual\.spec\.js/,
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
   ],
 
   /* Run your local dev server before starting the tests */

--- a/tests/visual/development.visual.spec.js
+++ b/tests/visual/development.visual.spec.js
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 // Helper function to check if dev server is running
 async function isServerRunning(page) {
   try {
-    await page.goto('http://localhost:3000', { timeout: 5000 });
+    await page.goto('/', { timeout: 5000 });
     return true;
   } catch (error) {
     return false;
@@ -11,34 +11,33 @@ async function isServerRunning(page) {
 }
 
 test.describe('Visual Development', () => {
+  // Skip entire suite if dev server isn't available
+  test.skip(!process.env.DEV_SERVER_RUNNING, 'Dev server not running');
+
   test('compare with mock', async ({ page }) => {
-    test.skip(!process.env.DEV_SERVER_RUNNING, 'Dev server not running');
-    
     const serverRunning = await isServerRunning(page);
-    test.skip(!serverRunning, 'Cannot connect to localhost:3000');
-    
+    test.skip(!serverRunning, 'Cannot connect to dev server');
+
     await expect(page).toHaveScreenshot('homepage.png', {
       maxDiffPixels: 100,
       threshold: 0.2,
       fullPage: true
     });
   });
-  
+
   test('responsive breakpoints', async ({ page }) => {
-    test.skip(!process.env.DEV_SERVER_RUNNING, 'Dev server not running');
-    
     const serverRunning = await isServerRunning(page);
-    test.skip(!serverRunning, 'Cannot connect to localhost:3000');
-    
+    test.skip(!serverRunning, 'Cannot connect to dev server');
+
     const viewports = [
       { width: 375, height: 667, name: 'mobile' },
       { width: 768, height: 1024, name: 'tablet' },
       { width: 1920, height: 1080, name: 'desktop' }
     ];
-    
+
     for (const viewport of viewports) {
       await page.setViewportSize(viewport);
-      await page.goto('http://localhost:3000');
+      await page.goto('/');
       await expect(page).toHaveScreenshot(`responsive-${viewport.name}.png`);
     }
   });


### PR DESCRIPTION
## Summary
- refine Playwright CLI tests with edge cases and explicit stderr checks
- mark mobile command as fixme and add isolated temp directories for CLI tests
- decouple visual spec from localhost and skip when dev server absent

## Testing
- `npm run test:cli`
- `npm test`
- `npm run visual:test`


------
https://chatgpt.com/codex/tasks/task_e_68aa2a995e808331b779c065cd8fd1bf