### PR TITLE
docs: catalog commands and agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,42 @@ MultiAgent-Claude/
         └── index.json                 # Quick lookup index
 ```
 
+## Agent & Command Templates
+
+- `Examples/commands/README.md` lists reusable CLI command templates and selection guidelines (e.g., `/wave-execute`, `/generate-tests`, `/implement-feature`).
+- `Examples/agents/README.md` catalogs available orchestrator and specialist agents with their trigger keywords.
+
+### Command Templates
+- `/wave-execute` - Runs the full 7-wave orchestration cycle with context propagation
+- `/generate-tests` - Generates comprehensive Playwright test plans
+- `/implement-feature` - Coordinates full-stack feature delivery via planning then execution
+- `TEMPLATE-COMMAND` - Starter template for creating new commands
+
+### Orchestrator Agents
+- code-review-orchestrator
+- fullstack-feature-orchestrator
+- infrastructure-migration-architect
+- issue-triage-orchestrator
+- master-orchestrator
+- parallel-controller
+- wave-execution-orchestrator
+
+### Specialist Agents
+- ai-agent-architect
+- aws-backend-architect
+- aws-deployment-specialist
+- backend-api-frontend-integrator
+- codebase-truth-analyzer
+- cpp-plugin-api-expert
+- documentation-architect
+- frontend-ui-expert
+- implementation-verifier
+- multimodal-ai-specialist
+- playwright-test-engineer
+- playwright-visual-developer
+- ui-design-auditor
+- vercel-deployment-troubleshooter
+
 ## Role Guidelines
 
 ### When Working on CLI Development

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,13 +15,15 @@ This project is running MultiAgent-Claude on itself! The framework manages its o
 ```
 MultiAgent-Claude/
 ├── Examples/                          # Templates for user projects
-│   └── agents/                        # Agent template library
-│       ├── orchestrators/             # Opus-model coordination agents
-│       │   └── [orchestrator agents].md
-│       ├── specialists/               # Sonnet-model domain experts
-│       │   ├── TEMPLATE-agent.md     # Base template
-│       │   └── [specialist agents].md
-│       └── manifest.json              # Template registry
+│   ├── agents/                        # Agent template library (see Examples/agents/README.md)
+│   │   ├── orchestrators/             # Opus-model coordination agents
+│   │   ├── specialists/               # Sonnet-model domain experts
+│   │   ├── TEMPLATE-agent.md         # Base template
+│   │   ├── [agent templates].md
+│   │   └── manifest.json              # Template registry
+│   └── commands/                      # Command template library (see Examples/commands/README.md)
+│       ├── README.md                  # Command catalog and selection guide
+│       └── [command templates].md
 ├── cli/                 # CLI implementation
 │   ├── index.js         # Main CLI entry point
 │   └── commands/        # CLI command implementations
@@ -594,6 +596,6 @@ The CI/CD workflows are optimized to prevent spam commits:
 
 - Review `claude-code-init-prompts.md` for complete initialization workflow
 - Check `memory-system-addon-prompt.md` for memory system details
-- Reference individual agent templates for specialization patterns
-- Use command templates for consistent workflow implementation
+- See `Examples/agents/README.md` for orchestrator and specialist catalogs
+- Consult `Examples/commands/README.md` for command templates and selection guidelines
 - Run `mac --help` for CLI documentation

--- a/Examples/agents/README.md
+++ b/Examples/agents/README.md
@@ -1,0 +1,37 @@
+# Agent Templates
+
+MultiAgent-Claude distinguishes between **orchestrators** that coordinate work and **specialists** that provide deep domain plans. All agents operate in a research-only mode and output implementation plans to `.claude/doc/`.
+
+## Orchestrators
+
+| Agent | Purpose | Trigger Keywords |
+|-------|---------|-----------------|
+| `code-review-orchestrator` | Coordinates multi‑angle code reviews before merge or deploy | `code review`, `audit` |
+| `fullstack-feature-orchestrator` | Manages end‑to‑end feature delivery across frontend and backend | `fullstack feature`, `frontend + backend` |
+| `infrastructure-migration-architect` | Plans large‑scale infrastructure transitions | `infrastructure migration`, `re‑architecture` |
+| `issue-triage-orchestrator` | Leads systematic bug investigation and resolution | `bug triage`, `performance issue` |
+| `master-orchestrator` | Analyzes tasks and selects execution strategy | `task analysis`, `strategy` |
+| `parallel-controller` | Oversees parallel agent execution with dependency control | `parallel tasks`, `concurrency` |
+| `wave-execution-orchestrator` | Runs the 7‑wave workflow for complex efforts | `7-wave`, `multi‑phase` |
+
+## Specialists
+
+| Agent | Expertise | Trigger Keywords |
+|-------|-----------|-----------------|
+| `ai-agent-architect` | Designs AI agent systems and MCP servers | `LangChain`, `agent orchestration` |
+| `aws-backend-architect` | Architects AWS backend services | `AWS architecture`, `serverless` |
+| `aws-deployment-specialist` | Troubleshoots and optimizes AWS deployments | `Terraform`, `CloudFormation` |
+| `backend-api-frontend-integrator` | Aligns APIs with frontend consumers | `API integration`, `frontend↔backend` |
+| `codebase-truth-analyzer` | Compares code and documentation for drift | `documentation alignment` |
+| `cpp-plugin-api-expert` | Guides C++ game engine plugin development | `C++ plugin`, `engine API` |
+| `documentation-architect` | Plans comprehensive project documentation | `documentation`, `docs planning` |
+| `frontend-ui-expert` | Provides React/Next.js UI guidance | `React 19`, `Tailwind`, `Shadcn` |
+| `implementation-verifier` | Validates that execution matches the plan | `plan adherence`, `verification` |
+| `multimodal-ai-specialist` | Plans vision‑language and RAG features | `CLIP`, `LLaVA`, `RAG` |
+| `playwright-test-engineer` | Designs Playwright test suites | `E2E tests`, `visual regression` |
+| `playwright-visual-developer` | Iterates on UI using Playwright MCP | `visual iteration`, `Playwright MCP` |
+| `ui-design-auditor` | Audits UX/UI and suggests improvements | `design audit`, `UX best practices` |
+| `vercel-deployment-troubleshooter` | Diagnoses Vercel build and runtime errors | `Vercel`, `deployment issues` |
+| `TEMPLATE-agent` | Starter spec for creating new specialists | `custom agent`, `template` |
+
+Refer to each markdown file for full instructions. Use orchestrators when coordination across multiple specialists is required; otherwise invoke the specialist that matches the domain.

--- a/Examples/commands/README.md
+++ b/Examples/commands/README.md
@@ -1,0 +1,21 @@
+# Command Templates
+
+This directory provides reusable command patterns for the MultiAgent-Claude CLI. Each command follows the research → plan → execute workflow where specialist agents create plans and the main system executes them.
+
+## Available Commands
+
+| Command | Purpose | When to Use |
+|--------|---------|-------------|
+| `/wave-execute` | Runs the full 7‑wave orchestration cycle with context propagation. | Choose for complex, multi‑phase tasks that require discovery, implementation, testing, deployment and documentation.
+| `/generate-tests` | Generates comprehensive Playwright test plans. | Use when adding or expanding end‑to‑end or visual regression tests.
+| `/implement-feature` | Coordinates full‑stack feature delivery via planning then execution. | Invoke for end‑to‑end features touching frontend and backend code.
+| `TEMPLATE-COMMAND` | Starter template for creating new commands. | Copy when defining a new custom command following the standard workflow.
+
+## Selection Guidelines
+
+1. Prefer `/wave-execute` for large efforts needing strict phase boundaries.
+2. Use `/implement-feature` for feature work that spans multiple stacks.
+3. Pick `/generate-tests` when the primary goal is Playwright test coverage.
+4. Start from `TEMPLATE-COMMAND` for any new command designs.
+
+All commands expect plans to be written to `.claude/doc/` and tests run via `npm test` before committing changes.


### PR DESCRIPTION
## Summary
- expand agent and command overview with command template listings
- document command and agent catalogs in CLAUDE.md's project structure and support resources

## Testing
- `npm test` *(fails: browserType.launch executable doesn't exist)*
- `npx playwright install` *(fails: server returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2a96fc688331b294cbcdbb0baec8